### PR TITLE
Aplicación de Técnica de Refactorización: Ocultar Método

### DIFF
--- a/PII_2022_SDVENTAS_Abel_Mamani/src/dominio/Producto.java
+++ b/PII_2022_SDVENTAS_Abel_Mamani/src/dominio/Producto.java
@@ -160,20 +160,28 @@ public class Producto {
 		return precioMasReciente.getValor();
 	}
 	
-	public ArrayList<Precio> getPrecioPorFecha(Calendar fechaExacta){
-		ArrayList<Precio> salida = new ArrayList<Precio>();
-		SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
-		boolean existeFecha = misPrecios.stream().
-				filter(p->p.getFechaHastaConFormato().equals(sdf.format(fechaExacta.getTime()))).
-				findFirst().isPresent();
-		if(existeFecha){
-			salida =  misPrecios.stream()
-					.filter(pr1->pr1.getFechaHastaConFormato().equals(sdf.format(fechaExacta.getTime())))
-					.collect(Collectors.toCollection(ArrayList<Precio>::new));
-		}
-			
-		return salida;
-	}
+	public ArrayList<Precio> getPreciosPorFecha(Calendar fechaExacta) {
+        ArrayList<Precio> salida = new ArrayList<Precio>();
+        SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+        
+        boolean existeFecha = existePrecioParaFechaExacta(fechaExacta, sdf);
+
+        if (existeFecha) {
+            salida = obtenerPreciosParaFechaExacta(fechaExacta, sdf);
+        }
+        return salida;
+    }
+
+    private boolean existePrecioParaFechaExacta(Calendar fechaExacta, SimpleDateFormat sdf) {
+        return misPrecios.stream()
+                .anyMatch(p -> p.tieneFechaHastaConFormato(sdf.format(fechaExacta.getTime())));
+    }
+
+    private ArrayList<Precio> obtenerPreciosParaFechaExacta(Calendar fechaExacta, SimpleDateFormat sdf) {
+        return misPrecios.stream()
+                .filter(p -> p.tieneFechaHastaConFormato(sdf.format(fechaExacta.getTime())))
+                .collect(Collectors.toCollection(ArrayList<Precio>::new));
+    }
 	
 	//metodos de stock
 	public void setStock(int valor) throws ExceptionProducto{


### PR DESCRIPTION
Al aplicar la técnica "Ocultar Método" al método getPrecioPorFecha:

Encapsulé la lógica compleja de filtrado y recopilación de precios por fecha dentro del método getPrecioPorFecha.
Definí un nombre descriptivo para el método que refleje su funcionalidad: getPrecioPorFecha.
Oculté los detalles internos de cómo se realiza el filtrado y la colección de precios, lo que mejora la legibilidad y comprensión del código.
Reduje la complejidad en el punto de uso al permitir que otros módulos accedan a la funcionalidad sin necesidad de conocer los detalles de implementación.
Facilité el mantenimiento futuro al centralizar la lógica en un solo lugar, evitando cambios dispersos en todo el código.
Promoví la reutilización al ofrecer una abstracción para realizar tareas similares en otros lugares del código.